### PR TITLE
Added Clojure highlighting to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,47 +13,48 @@ The library depends upon `clj-oauth' version 1.2.1 and which is in [clojars.org]
 
 # Example #
 
-    (require '[clj-dropbox.client :as dropbox])
+```clojure
+(require '[clj-dropbox.client :as dropbox])
 
-    ; First you make a `consumer' which represents your 
-    ; Dropbox  credientials you need to interact with Dropbox's OAuth. 
-    (def consumer (dropbox/new-consumer "my-developer-key" "my-developer-secret"))
+; First you make a `consumer' which represents your 
+; Dropbox  credientials you need to interact with Dropbox's OAuth. 
+(def consumer (dropbox/new-consumer "my-developer-key" "my-developer-secret"))
 
-    ; You need to do the OAuth dance in order
-    ; to get the user-key and user-secret. You
-    ; should persistently store these. 
-    (let [[authorization-url request-callback] 
-             (dropbox/request-user-authorization consumer my-callback-url)]
-      ; User grants you access
-      (println "Dear user authorize me at " authorization-url)
-      ; After this is done and my-callback-url is pinged 
-      ; (you can leave my-callback-url as  nil)
-      (let [[user-key user-secret] (request-callback)]
-        (println "I have user token info!")))  
+; You need to do the OAuth dance in order
+; to get the user-key and user-secret. You
+; should persistently store these. 
+(let [[authorization-url request-callback] 
+	 (dropbox/request-user-authorization consumer my-callback-url)]
+  ; User grants you access
+  (println "Dear user authorize me at " authorization-url)
+  ; After this is done and my-callback-url is pinged 
+  ; (you can leave my-callback-url as  nil)
+  (let [[user-key user-secret] (request-callback)]
+    (println "I have user token info!")))  
 
-    ; Once you have user-key and user-secret, make a client 
-    (def client (dropbox/new-user-client consumer user-key user-secret))
+; Once you have user-key and user-secret, make a client 
+(def client (dropbox/new-user-client consumer user-key user-secret))
 
-    ; Now you can do the fun stuff (see src/clj-dropbox/client.clj)
+; Now you can do the fun stuff (see src/clj-dropbox/client.clj)
 
-    ; Upload local file to dropbox
-    (dropbox/upload-file client "/path/to-local-file.txt" "dropbox-dir/")
+; Upload local file to dropbox
+(dropbox/upload-file client "/path/to-local-file.txt" "dropbox-dir/")
 
-    ; List files in root dropbox directory
-    ; returns seq of file meta-data 
-    (dropbox/list-files client "")
+; List files in root dropbox directory
+; returns seq of file meta-data 
+(dropbox/list-files client "")
 
-    ; Get the contents of a file as a string
-    (dropbox/get-file client "tmp/my-great-idea.txt")
+; Get the contents of a file as a string
+(dropbox/get-file client "tmp/my-great-idea.txt")
 
-    ; If you want to do several operations with the same user
-    ; on the same thread, you can save yourself the trouble
-    ; of using the client argument everywhere
-    (dropbox/with-user (new-user-client consumer user-key user-secret)
-      (doseq [[i f] (indexed (dropbox/list-files "")) 
-            :when (= (-> f :path (.endsWith ".txt")))]
-        (dropbox/copy-file (:path f) (str "my-text-files/txt-file-" i))))
-    
+; If you want to do several operations with the same user
+; on the same thread, you can save yourself the trouble
+; of using the client argument everywhere
+(dropbox/with-user (new-user-client consumer user-key user-secret)
+  (doseq [[i f] (indexed (dropbox/list-files "")) 
+	:when (= (-> f :path (.endsWith ".txt")))]
+    (dropbox/copy-file (:path f) (str "my-text-files/txt-file-" i))))
+```
 
 # Author #
 Aria Haghighi (aria42@gmail.com) 


### PR DESCRIPTION
I was choosing between Dropbox APIs &mdash; this one or [`Jopbox`](https://github.com/samrat/jopbox).

Initially I was attracted to the Jopbox implementation because the README was easier to read with the syntax highlighting, but switched back to your implementation because you mention the callback URL can be `nil`.

> Etc... etc.. etc...

In a nutshell I decided to add syntax highlighting to your README, just in case anybody else is as superficial as me.
